### PR TITLE
chore(release): add automated release workflow

### DIFF
--- a/.github/workflows/notify-pr-close.yml
+++ b/.github/workflows/notify-pr-close.yml
@@ -1,0 +1,24 @@
+name: Notify on PR close
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  release-reminder:
+    name: Remind to release
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'To create a release, please trigger the release workflow: https://github.com/canonical/rocks-toolbox/actions/workflows/release.yml'
+            })

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag (Optional, without 'v' e.g. 1.2.3)"
+
+jobs:
+  release:
+    name: Tag and release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version and push tag
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false
+          custom_tag: ${{ github.event.inputs.tag }}
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          name: ${{ steps.tag_version.outputs.new_tag }}
+          tag_name: ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          generate_release_notes: true


### PR DESCRIPTION
Adds a workflow file which can be run to create a semantic tag and immediately afterwards, create a release on GitHub.

Any collaborator with write access should be able to trigger the workflow.

This commit also adds another workflow file, which leaves a comment after a PR has been merged. The comment reminds to trigger the aforementioned release workflow.